### PR TITLE
Fix compilation with gcc 5

### DIFF
--- a/riscv.cfg
+++ b/riscv.cfg
@@ -107,7 +107,7 @@ default=default=default=default:
 # those settings by default, however some of the SPEC benchmarks require 
 # glibc.
 
-CC  = riscv64-unknown-linux-gnu-gcc -static -Wl,-Ttext-segment,0x10000
+CC  = riscv64-unknown-linux-gnu-gcc -static -std=gnu89 -Wl,-Ttext-segment,0x10000
 CXX = riscv64-unknown-linux-gnu-g++ -static -Wl,-Ttext-segment,0x10000
 FC  = riscv64-unknown-linux-gnu-gfortran -static -Wl,-Ttext-segment,0x10000
 


### PR DESCRIPTION
The switch from gnu89 to gnu11 changed the behavior of extern inline.
