### PR TITLE
Add compatibility flag to make 416.gamess work

### DIFF
--- a/riscv.cfg
+++ b/riscv.cfg
@@ -134,6 +134,9 @@ PORTABILITY    = -DSPEC_CPU_LP64
 400.perlbench=default=default=default:
 CPORTABILITY   = -DSPEC_CPU_LINUX_X64 -std=gnu89 
 
+416.gamess=default=default=default:
+CPORTABILITY   =  -funconstrained-commons
+
 462.libquantum=default=default=default:
 CPORTABILITY   =  -DSPEC_CPU_LINUX
 


### PR DESCRIPTION
This flag requires at least GCC 6.  I haven't actually re-run Speckle with this configuration-file change, but I did confirm that manually adding this flag works around the bug.

Closes #6.