### PR TITLE
482.sphinx3 assumes char is signed; make it so

### DIFF
--- a/riscv.cfg
+++ b/riscv.cfg
@@ -140,6 +140,9 @@ CPORTABILITY   =  -funconstrained-commons
 462.libquantum=default=default=default:
 CPORTABILITY   =  -DSPEC_CPU_LINUX
 
+482.sphinx3=default=default=default:
+CPORTABILITY   =  -fsigned-char
+
 483.xalancbmk=default=default=default:
 CXXPORTABILITY = -DSPEC_CPU_LINUX
 


### PR DESCRIPTION
In RISC-V (and ARM), char is unsigned.  482.sphinx3 incorrectly assumes char is always signed.