### PR TITLE
h264ref assumes that char is signed

### DIFF
--- a/riscv.cfg
+++ b/riscv.cfg
@@ -140,6 +140,9 @@ CPORTABILITY   =  -funconstrained-commons
 462.libquantum=default=default=default:
 CPORTABILITY   =  -DSPEC_CPU_LINUX
 
+464.h264ref=default=default=default:
+CPORTABILITY   =  -fsigned-char
+
 482.sphinx3=default=default=default:
 CPORTABILITY   =  -fsigned-char
 


### PR DESCRIPTION
Without the '-fsigned-char' flag h264ref will miscompare on RISC-V.